### PR TITLE
Missing path to the language string

### DIFF
--- a/simplebsslider/simplebsslider.xml
+++ b/simplebsslider/simplebsslider.xml
@@ -15,10 +15,10 @@
 		<folder>tmpl</folder>
 	</files>
 	<languages folder="language">
-		<language tag="en-GB">en-GB.plg_fields_simplebsslider.ini</language>
-		<language tag="en-GB">en-GB.plg_fields_simplebsslider.sys.ini</language>
-		<language tag="fr-FR">fr-FR.plg_fields_simplebsslider.ini</language>
-		<language tag="fr-FR">fr-FR.plg_fields_simplebsslider.sys.ini</language>
+		<language tag="en-GB">en-GB/en-GB.plg_fields_simplebsslider.ini</language>
+		<language tag="en-GB">en-GB/en-GB.plg_fields_simplebsslider.sys.ini</language>
+		<language tag="fr-FR">fr-FR/fr-FR.plg_fields_simplebsslider.ini</language>
+		<language tag="fr-FR">fr-FR/fr-FR.plg_fields_simplebsslider.sys.ini</language>
 	</languages>
 	<config>
 		<fields name="params">


### PR DESCRIPTION
### Summary of Changes
Add parent's folder name in order to pass Joomla installation process without any warnings in the XML file.

### Multilanguage Status
Enabled

### Joomla! Statistics
* PHP Version 7.0.6
* DB Type mysqli
* DB Version 5.5.5
* CMS Version 3.7.2
* Server OS Windows NT 10.0